### PR TITLE
Add team health check-in post

### DIFF
--- a/.claude/skills/spencer-writing-voice/SKILL.md
+++ b/.claude/skills/spencer-writing-voice/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: spencer-writing-voice
+description: Use when drafting or editing blog posts, manager-readme-style pages, or other prose meant to sound like Spencer Barton for the sbarton272.github.io site — captures tone, structure, and formatting conventions from his existing writing.
+---
+
+# Spencer Writing Voice
+
+## When to use
+
+Any time you're producing prose that will be published under Spencer's name on `sbarton272.github.io` — blog posts in `_posts/`, pages in `_pages/`, drafts in `_drafts/`, or content that mirrors that style.
+
+## Voice principles
+
+- **Talk to the reader.** Direct second person ("you've got", "guard your most productive hours"). Avoid third-person corporate framing.
+- **Modest and humane.** Light self-disclosure ("I find", "I sometimes", "I've taught"), but sparing. Never preachy. Acknowledge that the reader is smart.
+- **Practical and concrete.** Name actual tools, link to real resources (Clockwise, Atlassian playbooks, books, articles). No abstract jargon.
+- **Acknowledge nuance.** Avoid absolutes. "Sometimes this is unavoidable however it's rarely sustainable" is the shape — state the rule, then the honest exception.
+- **Conversational contractions.** "you're", "don't", "it's".
+- **Generous whitespace.** Short paragraphs, blank lines between bullets, easy to skim.
+- **No buzzwords or hype.** "Synergy", "leverage", "stakeholder alignment" — out. Plain language.
+
+## Structural conventions
+
+- **Question-headed sections.** Most section headers are questions: "Why try to improve your time management?", "What are the constraints on your time?", "How to make the best of the available time".
+- **Bold lead-in + bullets.** Each idea inside a section starts with a bold sentence stating the point, followed by 2–4 supporting bullets that unpack it. Example: `**Don't let meetings control your life.**` → bullets with concrete tactics.
+- **TLDR for longer pieces.** Open with three quick bullets summarizing the stance (see Manager Readme).
+- **"Further reading" closer.** End longer pieces with a short list of external links.
+- **Emoji section markers are optional flavor.** Used on the Manager Readme (🥖 📐 ♻️), skipped on the time-management post. Use them when the piece is personal/reflective; skip on tactical how-tos.
+
+## Jekyll frontmatter template
+
+```yaml
+---
+layout: post
+title:  Your Title Here
+description: One-sentence summary that would fit on a card.
+tags: management
+toc:
+  beginning: true   # only for longer pieces with multiple sections
+---
+```
+
+For pages in `_pages/`, use `layout: page`, add `permalink:` and `nav:` / `nav_order:`.
+
+## Before / after
+
+**Generic / corporate:**
+> Effective time management is a critical competency for high-performing professionals. By leveraging best-in-class productivity frameworks, individuals can optimize their workflow and maximize output.
+
+**In voice:**
+> **You probably don't know where your time goes.**
+>
+> - Periodically it can be really informative to perform a time study. This will let you see in detail where your time goes.
+> - I recommend recording your time every 30 min for a typical week.
+> - Tools like [TogglTrack](https://toggl.com/track/) or a simple spreadsheet can help.
+
+## Anti-patterns
+
+- Third-person passive ("it is recommended that teams should…")
+- Buzzwords (synergy, leverage, ideate, circle back, stakeholder alignment)
+- Lecturing tone or absolutes ("you must always", "never")
+- Walls of text — break into bullets with bold lead-ins
+- Inventing tools, books, or quotes — only link to things that actually exist
+- Heavy emoji use on tactical posts (save them for personal/reflective pages)

--- a/_posts/2026-06-09-measuring-team-health.md
+++ b/_posts/2026-06-09-measuring-team-health.md
@@ -5,65 +5,32 @@ description: A simple check-in template for keeping a pulse on how your team is 
 tags: management
 ---
 
-#### Why measure team health?
+### How to check in on team health?
 
-It's easy to track whether a team is shipping. It's much harder to notice when trust is fraying, ownership is muddy, or people haven't had a focused hour in two weeks. By the time those things show up in your delivery metrics, you're already behind.
+- You've likely read the books (provide links to key ones)
+- Healthy teams all about trust, accountability, etc.
+- But how do you actually drive a conversation around this?
+- Here's one piece that works for me, my version of the sprint retro
+- Informed heavily by [Atlassian Team Health Monitor](https://www.atlassian.com/team-playbook/health-monitor)
+- TODO attach an image of it in action
 
-A lightweight team health check gives you and the team shared language to talk about how things are going, before the wheels come off. I like [Atlassian's Team Health Monitor](https://www.atlassian.com/team-playbook/health-monitor) as a starting point and have adapted it into [a Google Doc template](https://docs.google.com/document/d/1aL_sxtmAtxN4GWNlQTOwovULa3Ja8LqKweO2yAPwaXk/edit?tab=t.0#heading=h.3lfjog6q165) you're welcome to copy.
+### How to run it
 
-#### How to run the check-in
-
-- **Pick a cadence.** Monthly or once a sprint works well. Quarterly is the slowest I'd go.
-- **Rate each dimension red / yellow / green.** Have people score individually first so you don't anchor on the loudest voice in the room.
-- **Talk about the reds and yellows.** The score is just a prompt, the discussion is where the value is.
+- Important part is spurring the conversation NOT the actual scoring
+- Adjust to your needs, I added focus time after folks brought up too many meetings in 1-1s and this helped us talk about and identify things to cut
+- Helps to have a driver, can jump start convo by calling out areas with lots of yellow / red.
+- Can ask people specifically why their yellow or red
+- Teams I manage rotate the meeting driver monthly, makes this exercise more team driven
 - **Pick one or two things to act on.** Don't try to fix everything at once.
 
-#### The dimensions to check on
+### Template
 
-**Collaborate radically (trust).**
-
-- Do we share a common understanding of why we're here and what we're solving?
-- Are we convinced about the idea and confident we have what we need to pull it off?
-- Do we actually trust each other?
-
-**Direction and goals.**
-
-- Is it clear what success looks like, both for the business and for our users?
-- Do we have a unique value proposition for our target users?
-- Is success defined with a goal and a way to measure it?
-
-**Ownership clarity.**
-
-- Are roles and responsibilities clear and agreed upon?
-- Do we have the right blend of skills on the team?
-- Have we acknowledged that the team can and should change as the project moves through stages?
-
-**Managed dependencies.**
-
-- Do we have a clear read on the complexity, infrastructure, risks, resources, effort, and timeline?
-- Do we know who we depend on, and who depends on us?
-
-**Continuous improvement.**
-
-- Are we shipping concrete iterations to stakeholders, and ideally to production?
-- Are we learning along the way and actually implementing what we learn?
-- Can we point to ways the team has gotten better recently?
-
-**Focus time.**
-
-- Did you have enough uninterrupted time to get real work done this week?
-
-**Velocity.**
-
-- Does your development workflow feel efficient?
-- Are you blocked anywhere?
-
-#### One thing to keep in mind
-
-The point isn't the score. It's the conversation. A team that talks honestly about a yellow rating is in much better shape than a team that quietly marks everything green. If you're consistently getting all greens, your check-in probably isn't safe enough yet.
+- Take a look at the descriptions in the template
+- I like to track thngs like trust, direction, focus time
+- [My team health check-in template (Google Doc)](https://docs.google.com/document/d/1aL_sxtmAtxN4GWNlQTOwovULa3Ja8LqKweO2yAPwaXk/edit?tab=t.0#heading=h.3lfjog6q165)
 
 #### Further reading
 
 - [Atlassian Team Health Monitor](https://www.atlassian.com/team-playbook/health-monitor)
-- [My team health check-in template (Google Doc)](https://docs.google.com/document/d/1aL_sxtmAtxN4GWNlQTOwovULa3Ja8LqKweO2yAPwaXk/edit?tab=t.0#heading=h.3lfjog6q165)
 - [Atlassian Team Playbook](https://www.atlassian.com/team-playbook)
+- TODO link Drive book, the Google Psyc Safety research?

--- a/_posts/2026-06-09-measuring-team-health.md
+++ b/_posts/2026-06-09-measuring-team-health.md
@@ -1,0 +1,69 @@
+---
+layout: post
+title:  Measuring Team Health
+description: A simple check-in template for keeping a pulse on how your team is actually doing.
+tags: management
+---
+
+#### Why measure team health?
+
+It's easy to track whether a team is shipping. It's much harder to notice when trust is fraying, ownership is muddy, or people haven't had a focused hour in two weeks. By the time those things show up in your delivery metrics, you're already behind.
+
+A lightweight team health check gives you and the team shared language to talk about how things are going, before the wheels come off. I like [Atlassian's Team Health Monitor](https://www.atlassian.com/team-playbook/health-monitor) as a starting point and have adapted it into [a Google Doc template](https://docs.google.com/document/d/1aL_sxtmAtxN4GWNlQTOwovULa3Ja8LqKweO2yAPwaXk/edit?tab=t.0#heading=h.3lfjog6q165) you're welcome to copy.
+
+#### How to run the check-in
+
+- **Pick a cadence.** Monthly or once a sprint works well. Quarterly is the slowest I'd go.
+- **Rate each dimension red / yellow / green.** Have people score individually first so you don't anchor on the loudest voice in the room.
+- **Talk about the reds and yellows.** The score is just a prompt, the discussion is where the value is.
+- **Pick one or two things to act on.** Don't try to fix everything at once.
+
+#### The dimensions to check on
+
+**Collaborate radically (trust).**
+
+- Do we share a common understanding of why we're here and what we're solving?
+- Are we convinced about the idea and confident we have what we need to pull it off?
+- Do we actually trust each other?
+
+**Direction and goals.**
+
+- Is it clear what success looks like, both for the business and for our users?
+- Do we have a unique value proposition for our target users?
+- Is success defined with a goal and a way to measure it?
+
+**Ownership clarity.**
+
+- Are roles and responsibilities clear and agreed upon?
+- Do we have the right blend of skills on the team?
+- Have we acknowledged that the team can and should change as the project moves through stages?
+
+**Managed dependencies.**
+
+- Do we have a clear read on the complexity, infrastructure, risks, resources, effort, and timeline?
+- Do we know who we depend on, and who depends on us?
+
+**Continuous improvement.**
+
+- Are we shipping concrete iterations to stakeholders, and ideally to production?
+- Are we learning along the way and actually implementing what we learn?
+- Can we point to ways the team has gotten better recently?
+
+**Focus time.**
+
+- Did you have enough uninterrupted time to get real work done this week?
+
+**Velocity.**
+
+- Does your development workflow feel efficient?
+- Are you blocked anywhere?
+
+#### One thing to keep in mind
+
+The point isn't the score. It's the conversation. A team that talks honestly about a yellow rating is in much better shape than a team that quietly marks everything green. If you're consistently getting all greens, your check-in probably isn't safe enough yet.
+
+#### Further reading
+
+- [Atlassian Team Health Monitor](https://www.atlassian.com/team-playbook/health-monitor)
+- [My team health check-in template (Google Doc)](https://docs.google.com/document/d/1aL_sxtmAtxN4GWNlQTOwovULa3Ja8LqKweO2yAPwaXk/edit?tab=t.0#heading=h.3lfjog6q165)
+- [Atlassian Team Playbook](https://www.atlassian.com/team-playbook)


### PR DESCRIPTION
## Summary
- Adds a short blog post on measuring team health, with a check-in template covering trust/collaboration, direction & goals, ownership clarity, managed dependencies, continuous improvement, focus time, and velocity.
- Links to the Atlassian Team Health Monitor and a Google Doc template for running the check-in.

## Test plan
- [ ] `bundle exec jekyll serve` and confirm the post renders on `/blog/` without Liquid errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)