### PR TITLE
Upgrade Ruby to 3.4 and update deployment documentation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-bullseye
+FROM ruby:3.4-bookworm
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     imagemagick \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2.2'
+        ruby-version: '3.4'
         bundler-cache: true
     - name: Update _config.yml ⚙️
       uses: fjogeleit/yaml-update-action@v0.13.1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mise run dev
 Or manually:
 
 ```sh
-docker build -t sbarton-site .
+docker build -t sbarton-site -f .devcontainer/Dockerfile .
 docker run --rm -p 4000:4000 -v $(pwd):/srv/jekyll sbarton-site
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,34 @@ docker run --rm -p 4000:4000 -v $(pwd):/srv/jekyll sbarton-site
 ```
 
 Open http://localhost:4000. The `-v` mount means file changes trigger a rebuild without restarting the container.
+
+## Deployment
+
+The site is hosted on **GitHub Pages** and deploys automatically. The
+[`deploy`](.github/workflows/deploy.yml) GitHub Action runs on every push to
+`main`: it builds the Jekyll site with `JEKYLL_ENV=production` (Ruby 3.4) and
+publishes the generated `_site` to GitHub Pages. The custom domain is set via
+the [`CNAME`](CNAME) file.
+
+The same workflow also runs on pull requests, but as a **build-only check** (the
+deploy step is skipped). A green check on the PR means the production build
+succeeds; a red check means the build would break `main`, so fix it before
+merging.
+
+> **Note:** CI and the dev container both pin Ruby 3.4
+> ([`deploy.yml`](.github/workflows/deploy.yml) and
+> [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile)). If you bump the Ruby
+> version, update both so `Gemfile.lock` resolves the same way locally and in CI.
+
+### Testing the production build before opening a PR
+
+The dev container above runs the development build; to catch deploy failures
+early, reproduce the production build the Action runs. The quickest way is to
+run a bundle install + production build in the same Ruby version CI uses:
+
+```sh
+docker run --rm -v "$(pwd)":/srv/jekyll -w /srv/jekyll ruby:3.4-bookworm \
+  bash -c "bundle install && JEKYLL_ENV=production bundle exec jekyll build --lsi"
+```
+
+If that succeeds, the `deploy` workflow's build step will pass too.


### PR DESCRIPTION
## Summary
This PR upgrades the project's Ruby version from 3.2 to 3.4 across all environments and adds comprehensive deployment documentation to the README.

## Key Changes
- **Ruby version upgrade**: Updated Ruby from 3.2 to 3.4 in:
  - `.devcontainer/Dockerfile`: Changed base image from `ruby:3.2-bullseye` to `ruby:3.4-bookworm`
  - `.github/workflows/deploy.yml`: Updated CI Ruby version from `3.2.2` to `3.4`
  
- **Documentation**: Added new "Deployment" section to README covering:
  - GitHub Pages hosting and automatic deployment via GitHub Actions
  - How the `deploy` workflow builds with `JEKYLL_ENV=production` on pushes to `main`
  - PR build-only checks that validate production builds without deploying
  - Important note about keeping Ruby versions synchronized between CI and dev container
  - Instructions for locally testing the production build before opening a PR, including a Docker command to reproduce the exact CI environment

## Implementation Details
The Ruby version is now pinned to 3.4 consistently across development and CI environments. The documentation emphasizes the importance of keeping both `.devcontainer/Dockerfile` and `.github/workflows/deploy.yml` in sync to ensure `Gemfile.lock` resolves identically in both contexts.

https://claude.ai/code/session_01RbW3r2jFSSpq68Cfy16xWs