### PR TITLE
Remove Clockwise reference from manager readme

### DIFF
--- a/_pages/manager-readme.md
+++ b/_pages/manager-readme.md
@@ -183,7 +183,7 @@ I have less patience for ego, people talking over each other, meetings without a
 
 **How I focus**
 
-I'm best able to focus in a quiet environment where I can be distraction free for a spell. You may see me log off slack sometimes if I need time to get a project done. I'll also schedule work blocks and I try to cluster my meetings using tools like Clockwise.
+I'm best able to focus in a quiet environment where I can be distraction free for a spell. You may see me log off slack sometimes if I need time to get a project done. I'll also schedule work blocks and I try to cluster my meetings.
 
 
 ### 📖 Resources I constantly reference {#📖-resources-i-constantly-reference}


### PR DESCRIPTION
Removes the reference to Clockwise in the manager readme's "How I focus" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZM7fzU1em4rn5QAN39b7S)_